### PR TITLE
Add timestamp to sensor data

### DIFF
--- a/sensors/temperature_humidity/README.md
+++ b/sensors/temperature_humidity/README.md
@@ -29,6 +29,7 @@ temperature_humidity/
 
 ### 3. sensor.py - 传感器模块
 专门处理DHT22传感器的读取逻辑，包含重试机制和错误处理。
+从 `read()` 方法返回的数据中新增 `timestamp` 字段，记录读取时的 UTC 秒级时间戳（自 Unix Epoch 起的秒数）。
 
 ### 4. publisher.py - 发布者模块
 处理MQTT发布逻辑，继承自common模块的MQTT基类。

--- a/sensors/temperature_humidity/sensor.py
+++ b/sensors/temperature_humidity/sensor.py
@@ -29,7 +29,8 @@ class DHT22Sensor:
 
     def read(self) -> Optional[Dict[str, float]]:
         """
-        读取传感器数据，返回{'temperature': float, 'humidity': float}，失败返回None
+        读取传感器数据，返回{'temperature': float, 'humidity': float, 'timestamp': int}，
+        其中 `timestamp` 为自 Unix Epoch 起的 UTC 秒数。失败返回 None
         """
         for attempt in range(self.retry_count):
             try:
@@ -38,7 +39,8 @@ class DHT22Sensor:
                 if temperature is not None and humidity is not None:
                     data = {
                         'temperature': round(temperature, 2),
-                        'humidity': round(humidity, 2)
+                        'humidity': round(humidity, 2),
+                        'timestamp': int(time.time())  # UTC seconds since Unix Epoch
                     }
                     logger.debug(f"传感器数据读取成功: {data}")
                     return data


### PR DESCRIPTION
## Summary
- extend DHT22 sensor `read` output with `timestamp`
- document timestamp field in sensor module README
- clarify that the value is a Unix epoch seconds timestamp

## Testing
- `python -m py_compile sensors/temperature_humidity/sensor.py`
- `python -m py_compile sensors/temperature_humidity/publisher.py`
- `python -m py_compile sensors/temperature_humidity/temperature_humidity_pub.py`


------
https://chatgpt.com/codex/tasks/task_e_687da0e3131483318b2a4f8c29191662