### PR TITLE
Document buzzer MQTT interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 | 领域    | 主题前缀              | 格式示例                                 |
 | ----- | ----------------- | ------------------------------------ |
 | 传感器数据 | `sensor/{type}`   | `{"value": 23.5, "ts": 162}`         |
-| 执行器命令 | `actuator/{name}` | `{"cmd": "ON"/"OFF", "id": "node1"}` |
+| 执行器命令 | `actuator/{name}` | `{"action": true, "params": {"times": 3}}` |
 
 
 - **时间戳**：所有消息建议携带单位秒的 UTC 时间戳。
@@ -104,6 +104,17 @@
 ```python
 # 订阅 actuator/buzzer 主题，根据指令控制蜂鸣器鸣叫
 ```
+
+- **消息格式**：
+
+  ```json
+  {
+    "action": true,
+    "params": {"times": 3, "interval": 0.2}
+  }
+  ```
+
+  `action` 设为 `true` 时按参数鸣叫，设为 `false` 则停止当前蜂鸣。
 
 ---
 

--- a/actuators/buzzer/README.md
+++ b/actuators/buzzer/README.md
@@ -42,3 +42,29 @@ repeat = 2
    ```bash
    python buzzer_sub.py
    ```
+
+## 接口设计
+
+- **订阅主题**：`{topic_prefix}/buzzer`
+
+  `topic_prefix` 来自 `config.ini` 的 MQTT 配置，默认值 `actuator`。
+
+- **消息格式**：
+
+  ```json
+  {
+    "action": true,      // true 触发蜂鸣，false 停止
+    "params": {
+      "times": 3,        // 蜂鸣次数，可选
+      "interval": 0.2    // 间隔时长（秒），可选
+    }
+  }
+  ```
+
+  当 `action` 为 `true` 时，按照参数执行蜂鸣；`false` 则立即停止。
+
+- **示例**：
+
+  ```bash
+  mosquitto_pub -t actuator/buzzer -m '{"action": true, "params": {"times": 5, "interval": 0.1}}'
+  ```

--- a/actuators/buzzer/buzzer.py
+++ b/actuators/buzzer/buzzer.py
@@ -2,26 +2,37 @@
 """蜂鸣器控制模块"""
 import time
 from typing import Optional
+from .interface import BuzzerInterface
 
 try:
     from gpiozero import Buzzer
 except ImportError:  # 在没有硬件的环境下兼容
     Buzzer = None
 
-class SimpleBuzzer:
+class SimpleBuzzer(BuzzerInterface):
     """简单蜂鸣器控制类"""
+
     def __init__(self, pin: int):
         if Buzzer is None:
             raise RuntimeError("未安装gpiozero库，无法控制蜂鸣器")
         self.buzzer = Buzzer(pin)
+        self._running = False
 
     def beep(self, duration: float = 0.2, repeat: int = 1) -> None:
+        self._running = True
         for _ in range(repeat):
+            if not self._running:
+                break
             self.buzzer.on()
             time.sleep(duration)
             self.buzzer.off()
             time.sleep(duration)
+        self._running = False
 
     def close(self):
         if hasattr(self.buzzer, 'close'):
             self.buzzer.close()
+
+    def stop(self) -> None:
+        self._running = False
+        self.buzzer.off()

--- a/actuators/buzzer/controller.py
+++ b/actuators/buzzer/controller.py
@@ -28,14 +28,19 @@ class BuzzerSubscriber(MQTTSubscriber):
         logger.info("Buzzer订阅者初始化完成")
 
     def handle_message(self, topic: str, payload: Dict[str, Any]):
-        cmd = payload.get('cmd', 'ON')
-        if cmd.upper() == 'ON':
-            duration = float(payload.get('duration', self.beep_duration))
-            repeat = int(payload.get('repeat', self.repeat))
-            logger.info(f"执行蜂鸣指令: duration={duration}, repeat={repeat}")
-            self.buzzer.beep(duration=duration, repeat=repeat)
+        action = payload.get('action')
+        if action is True:
+            params = payload.get('params', {})
+            interval = float(params.get('interval', self.beep_duration))
+            times = int(params.get('times', self.repeat))
+            logger.info(
+                f"执行蜂鸣指令: interval={interval}, times={times}")
+            self.buzzer.beep(duration=interval, repeat=times)
+        elif action is False:
+            logger.info("停止蜂鸣指令")
+            self.buzzer.stop()
         else:
-            logger.warning(f"未知指令: {cmd}")
+            logger.warning(f"未知指令: {payload}")
 
     def stop(self):
         super().stop()

--- a/actuators/buzzer/interface.py
+++ b/actuators/buzzer/interface.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""蜂鸣器接口定义"""
+from abc import ABC, abstractmethod
+
+
+class BuzzerInterface(ABC):
+    """蜂鸣器接口"""
+
+    @abstractmethod
+    def beep(self, duration: float = 0.2, repeat: int = 1) -> None:
+        """鸣叫指定时长和次数"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self) -> None:
+        """释放蜂鸣器资源"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self) -> None:
+        """停止正在进行的蜂鸣"""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add `BuzzerInterface` base class
- implement interface in `SimpleBuzzer`
- document MQTT payload format for buzzer
- refine buzzer interface to support start/stop action

## Testing
- `python -m py_compile actuators/buzzer/interface.py actuators/buzzer/buzzer.py actuators/buzzer/controller.py`


------
https://chatgpt.com/codex/tasks/task_e_687da6fa2f8c83319c69b20d92d9a43c